### PR TITLE
Fetched project marketing version.

### DIFF
--- a/Guard/Guard.xcodeproj/project.pbxproj
+++ b/Guard/Guard.xcodeproj/project.pbxproj
@@ -1254,7 +1254,7 @@
 					"$(PROJECT_DIR)$(LOCAL_LIBRARY_DIR)",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 1.4.9.1;
+				MARKETING_VERSION = 1.4.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.authing.Guard;
@@ -1304,7 +1304,7 @@
 					"$(PROJECT_DIR)$(LOCAL_LIBRARY_DIR)",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 1.4.9.1;
+				MARKETING_VERSION = 1.4.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.authing.Guard;

--- a/Guard/Guard/Const.swift
+++ b/Guard/Guard/Const.swift
@@ -9,7 +9,7 @@ typealias AuthCallback = (Int, String?, UserInfo?) -> Void
 
 public class Const: NSObject {
     
-    public static let SDK_VERSION: String = (Bundle(identifier: "cn.authing.Guard")?.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "1.4.9.1"
+    public static let SDK_VERSION: String = (Bundle(identifier: "cn.authing.Guard")?.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "1.4.10"
     
     public static let Color_Authing_Main = UIColor(red: 33/255.0, green: 90/255.0, blue: 229/255.0, alpha: 1)
     public static let Color_Button_Pressed = UIColor(red: 0.039, green: 0.227, blue: 0.792, alpha: 1)


### PR DESCRIPTION
Fixed the error which may occur while preparing build for App Store Connect on Xcode Cloud.

```
This bundle is invalid. The value for key CFBundleShortVersionString '1.4.9.1' in the Info.plist file at 'Payload/some.app/Frameworks/Guard.framework' must be a period-separated list of at most three non-negative integers. Please find more information about CFBundleShortVersionString at https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring
```
